### PR TITLE
CarePartner app authentication

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -90,7 +90,7 @@ android {
 
     defaultConfig {
         applicationId "com.eveningoutpost.dexdrip"
-        minSdkVersion 19
+        minSdkVersion 23
         // increasing target SDK version can cause compatibility issues with Android 7+
         //noinspection ExpiredTargetSdkVersion
         targetSdkVersion 23
@@ -141,6 +141,8 @@ android {
         exclude 'META-INF/INDEX.LIST'
         exclude 'META-INF/NOTICE.md'
         exclude 'META-INF/LICENSE.md'
+        pickFirst 'org/bouncycastle/x509/CertPathReviewerMessages.properties'
+        pickFirst 'org/bouncycastle/x509/CertPathReviewerMessages_de.properties'
     }
 
     compileOptions {
@@ -289,6 +291,7 @@ dependencies {
     //implementation 'com.google.dagger:dagger-android-support:2.x' // if you use the support libraries
     annotationProcessor 'com.google.dagger:dagger-compiler:2.25.4'
     implementation 'net.danlew:android.joda:2.10.6.1'
+    implementation 'org.bouncycastle:bcpkix-jdk15to18:1.68'
     testImplementation 'joda-time:joda-time:2.10.7'
 
     testImplementation 'junit:junit:4.13.2'

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/auth/CareLinkAuthType.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/auth/CareLinkAuthType.java
@@ -1,0 +1,6 @@
+package com.eveningoutpost.dexdrip.cgm.carelinkfollow.auth;
+
+public enum CareLinkAuthType {
+    Browser,
+    MobileApp
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/auth/CareLinkAuthentication.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/auth/CareLinkAuthentication.java
@@ -1,0 +1,20 @@
+package com.eveningoutpost.dexdrip.cgm.carelinkfollow.auth;
+
+import okhttp3.Headers;
+
+public class CareLinkAuthentication {
+
+    public CareLinkAuthType authType;
+    private Headers.Builder builder;
+
+    public CareLinkAuthentication(Headers headers, CareLinkAuthType authType) {
+        this.builder = new Headers.Builder();
+        this.builder.addAll(headers);
+        this.authType = authType;
+    }
+
+    public Headers getHeaders() {
+        return builder.build();
+    }
+
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/auth/CareLinkAuthenticator.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/auth/CareLinkAuthenticator.java
@@ -2,25 +2,65 @@ package com.eveningoutpost.dexdrip.cgm.carelinkfollow.auth;
 
 import android.app.Activity;
 import android.app.Dialog;
+import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.graphics.Bitmap;
+import android.net.UrlQuerySanitizer;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.v7.widget.LinearLayoutCompat;
 import android.view.ViewGroup;
 import android.webkit.CookieManager;
+import android.webkit.WebResourceError;
+import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
+import com.eveningoutpost.dexdrip.R;
+import com.eveningoutpost.dexdrip.Models.UserError;
+import com.eveningoutpost.dexdrip.xdrip;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
 import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.KeyPair;
+import java.security.SecureRandom;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+
+import android.util.Base64;
+import android.widget.LinearLayout;
+import android.widget.ProgressBar;
+
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.bouncycastle.pkcs.PKCS10CertificationRequestBuilder;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
+
+import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.Semaphore;
 
+import javax.security.auth.x500.X500Principal;
+
+import okhttp3.ConnectionPool;
 import okhttp3.Cookie;
+import okhttp3.FormBody;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -29,11 +69,21 @@ import okhttp3.Response;
 
 public class CareLinkAuthenticator {
 
+    private static final String TAG = "CareLinkAuthenticator";
+
+    protected static final String CAREPARTNER_APP_DISCO_URL = "https://clcloud.minimed.com/connect/carepartner/v6/discover/android/3.1";
     protected static final String CARELINK_CONNECT_SERVER_EU = "carelink.minimed.eu";
     protected static final String CARELINK_CONNECT_SERVER_US = "carelink.minimed.com";
     protected static final String CARELINK_LANGUAGE_EN = "en";
     protected static final String CARELINK_AUTH_TOKEN_COOKIE_NAME = "auth_tmp_token";
     protected static final String CARELINK_TOKEN_VALIDTO_COOKIE_NAME = "c_token_valid_to";
+
+    protected static final String[] ANDROID_MODELS = {
+            "SM-G973F",
+            "SM-G988U1",
+            "SM-G981W",
+            "SM-G9600"
+    };
 
     protected static final SimpleDateFormat[] VALIDTO_DATE_FORMATS = {
             new SimpleDateFormat("EEE MMM d HH:mm:ss zzz yyyy", Locale.ENGLISH),
@@ -52,10 +102,19 @@ public class CareLinkAuthenticator {
             //new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX")
     };
 
+    private static final int PKCE_BASE64_ENCODE_SETTINGS =
+            Base64.NO_WRAP | Base64.NO_PADDING | Base64.URL_SAFE;
+
 
     private final Semaphore available = new Semaphore(0, true);
+    private AlertDialog progressDialog;
     private String carelinkCountry;
     private CareLinkCredentialStore credentialStore;
+    private CarePartnerAppConfig carepartnerAppConfig;
+    private String authCode = null;
+    private OkHttpClient httpClient = null;
+    private boolean authWebViewCancelled = false;
+    private boolean carelinkCommunicationError = false;
 
 
     public CareLinkAuthenticator(String carelinkCountry, CareLinkCredentialStore credentialStore) {
@@ -63,53 +122,426 @@ public class CareLinkAuthenticator {
         this.credentialStore = credentialStore;
     }
 
-    /*
-    public synchronized CareLinkCredential getCreditential() throws InterruptedException {
-        if(Looper.myLooper() == Looper.getMainLooper())
-            throw new RuntimeException("don't call getAccessToken() from the main thread.");
+    public boolean authenticate(Activity context, CareLinkAuthType authType) throws InterruptedException {
 
-        switch (credentialStore.getAuthStatus()) {
-            case CareLinkCredentialStore.NOT_AUTHENTICATED:
-                authenticate();
-                available.acquire();
-                break;
-            case CareLinkCredentialStore.TOKEN_EXPIRED:
-                refreshToken();
-                available.acquire();
-                break;
-            case CareLinkCredentialStore.AUTHENTICATED:
-                break;
-        }
-
-        return credentialStore.getCredential();
-    }
-     */
-
-    public boolean authenticate(Activity context) throws InterruptedException {
         if (Looper.myLooper() == Looper.getMainLooper())
             throw new RuntimeException("don't call authenticate() from the main thread.");
 
-        Handler handler = new Handler(Looper.getMainLooper());
-        handler.post(new Runnable() {
-            @Override
-            public void run() {
-                showDialog(context);
-            }
-        });
-        available.acquire();
+        //Execute authentication method of authentication type
+        switch (authType) {
+            case Browser:
+                this.authenticateAsBrowser(context);
+                break;
+            case MobileApp:
+                this.authenticateAsCpApp(context);
+                break;
+        }
+
+        //Return: is authenticated
         return (credentialStore.getAuthStatus() == CareLinkCredentialStore.AUTHENTICATED);
     }
 
     public boolean refreshToken() {
+        //Have credential, authType is known, already authenticated
+        if (credentialStore.getCredential() != null && credentialStore.getCredential().authType != null && credentialStore.getAuthStatus() != CareLinkCredentialStore.NOT_AUTHENTICATED) {
+            switch (credentialStore.getCredential().authType) {
+                case Browser:
+                    return this.refreshBrowserToken();
+                case MobileApp:
+                    return this.refreshCpAppToken();
+                default:
+                    return false;
+            }
+        } else {
+            return false;
+        }
+    }
+
+    private void authenticateAsCpApp(Activity context) {
+
+        String deviceId;
+        String androidModel;
+        String clientId;
+        String clientSecret;
+        String magIdentifier;
+        JsonObject clientCredential;
+        String codeVerifier;
+        String authUrl;
+        String idToken;
+        String idTokenType;
+
+        try {
+
+            carelinkCommunicationError = false;
+
+            //Show progress dialog while preparing for login page
+            this.showProgressDialog(context);
+
+            //Generate ID, models
+            deviceId = generateDeviceId();
+            androidModel = this.generateAndroidModel();
+
+            //Load application config
+            this.loadAppConfig();
+
+            //Create client credential
+            clientCredential = this.createClientCredential(deviceId);
+            clientId = clientCredential.get("client_id").getAsString();
+            clientSecret = clientCredential.get("client_secret").getAsString();
+
+            //Prepare authentication
+            UserError.Log.d(TAG, "Prepare authentication");
+            codeVerifier = generateRandomDataBase64url(32);
+            authUrl = this.prepareAuth(clientId, codeVerifier);
+
+            //Hide progress dialog
+            this.hideProgressDialog();
+
+            //Authenticate in browser
+            UserError.Log.d(TAG, "Start browser login");
+            new Handler(Looper.getMainLooper()).post(new Runnable() {
+                @Override
+                public void run() {
+                    CareLinkAuthenticator.this.showCpAppAuthPage(context, authUrl);
+                }
+            });
+            available.acquire();
+
+            //Continue if not cancelled and no error
+            if (!this.authWebViewCancelled && !carelinkCommunicationError) {
+                //Show progress dialog while completing authentication
+                this.showProgressDialog(context);
+
+                //Register device
+                UserError.Log.d(TAG, "Register device");
+                Response registerResp = this.registerDevice(deviceId, androidModel, clientId, clientSecret, authCode, codeVerifier);
+                magIdentifier = registerResp.header("mag-identifier");
+                idToken = registerResp.header("id-token");
+                idTokenType = registerResp.header("id-token-type");
+
+                //Get access token
+                UserError.Log.d(TAG, "Get access token");
+                JsonObject tokenObject = this.getAccessToken(clientId, clientSecret, magIdentifier, idToken, idTokenType);
+
+                //Store credentials
+                UserError.Log.d(TAG, "Store credentials");
+                this.credentialStore.setMobileAppCredential(this.carelinkCountry,
+                        deviceId, androidModel, clientId, clientSecret, magIdentifier,
+                        tokenObject.get("access_token").getAsString(), tokenObject.get("refresh_token").getAsString(),
+                        //new Date(Calendar.getInstance().getTime().getTime() + 15 * 60000),
+                        //new Date(Calendar.getInstance().getTime().getTime() + 30 * 60000));
+                        new Date(Calendar.getInstance().getTime().getTime() + (tokenObject.get("expires_in").getAsInt() * 1000)),
+                        new Date(Calendar.getInstance().getTime().getTime() + (this.carepartnerAppConfig.getRefreshLifetimeSec() * 1000)));
+
+                //Hide progress dialog
+                this.hideProgressDialog();
+            }
+
+        } catch (Exception ex) {
+            UserError.Log.e(TAG, "Error authenticating as CpApp. Details: \r\n " + ex.getMessage());
+            carelinkCommunicationError = true;
+            this.hideProgressDialog();
+        }
+
+        //Show communication error
+        if (carelinkCommunicationError) {
+            new Handler(Looper.getMainLooper()).post(new Runnable() {
+                @Override
+                public void run() {
+                    new AlertDialog.Builder(context)
+                            .setTitle("Communication error!")
+                            .setMessage("Error communicating with CareLink Server! Please try again later!")
+                            .setCancelable(true)
+                            .setNeutralButton(R.string.ok, new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialogInterface, int i) {
+                                    dialogInterface.cancel();
+                                }
+                            })
+                            .show();
+                }
+            });
+        }
+
+    }
+
+    private void authenticateAsBrowser(Activity context) throws InterruptedException {
+
+        //Authenticate in browser
+        new Handler(Looper.getMainLooper()).post(new Runnable() {
+            @Override
+            public void run() {
+                CareLinkAuthenticator.this.showBrowserAuthPage(context, "");
+            }
+        });
+        available.acquire();
+    }
+
+    private OkHttpClient getHttpClient() {
+        if (this.httpClient == null)
+            this.httpClient = new OkHttpClient();
+        return this.httpClient;
+    }
+
+    private boolean loadAppConfig() throws IOException {
+        if (carepartnerAppConfig == null) {
+            carepartnerAppConfig = new CarePartnerAppConfig();
+            UserError.Log.d(TAG, "Get region config");
+            carepartnerAppConfig.regionConfig = this.getCpAppRegionConfig();
+            UserError.Log.d(TAG, "Get SSO config");
+            carepartnerAppConfig.ssoConfig = this.getCpAppSSOConfig(carepartnerAppConfig.getSSOConfigUrl());
+        }
+        return true;
+    }
+
+    private JsonObject getAccessToken(String clientId, String clientSecret, String magIdentifier, String idToken, String idTokenType) throws IOException {
+        return this.getToken(clientId, clientSecret, magIdentifier, idToken, idTokenType, null);
+    }
+
+    private JsonObject refreshToken(String clientId, String clientSecret, String magIdentifier, String refreshToken) throws IOException {
+        return this.getToken(clientId, clientSecret, magIdentifier, null, null, refreshToken);
+    }
+
+    private JsonObject getToken(String clientId, String clientSecret, String magIdentifier, String idToken, String idTokenType, String refreshToken) throws IOException {
+
+        Request.Builder requestBuilder;
+        FormBody.Builder form;
+
+        //Common token request params
+        form = new FormBody.Builder()
+                .add("client_id", clientId)
+                .add("client_secret", clientSecret);
+        //Authentication token request params
+        if (idToken != null) {
+            form.add("assertion", idToken)
+                    .add("grant_type", idTokenType)
+                    .add("scope", this.carepartnerAppConfig.getOAuthScope());
+            //Refresh token request params
+        } else {
+            form.add("refresh_token", refreshToken)
+                    .add("grant_type", "refresh_token");
+        }
+
+        requestBuilder = new Request.Builder()
+                .post(form.build())
+                .addHeader("mag-identifier", magIdentifier)
+                .header("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8");
+
+        return this.callSsoRestApi(requestBuilder, carepartnerAppConfig.getOAuthTokenEndpoint(), null);
+
+    }
+
+    private Response registerDevice(String deviceId, String androidModel, String clientId, String clientSecret, String authCode, String codeVerifier) throws IOException {
+
+        String trimmedCsr = null;
+
+        //Create RSA2048 keypair and CSR
+        try {
+            KeyPairGenerator keygen = KeyPairGenerator.getInstance("RSA");
+            keygen.initialize(2048);
+            KeyPair keypair = keygen.genKeyPair();
+            trimmedCsr = createTrimmedCsr(keypair, "SHA256withRSA", "socialLogin", deviceId, androidModel, "Medtronic");
+        } catch (Exception e) {
+            UserError.Log.e(TAG, "Error creating CSR! Details: \r\n" + e.getMessage());
+        }
+
+        //Register device and get certificate for CSR
+        RequestBody body;
+        Request.Builder requestBuilder;
+
+        body = RequestBody.create(null, trimmedCsr);
+
+        requestBuilder = new Request.Builder()
+                .post(body)
+                .addHeader("device-id", Base64.encodeToString(deviceId.getBytes(StandardCharsets.UTF_8), Base64.NO_WRAP))
+                .addHeader("device-name", Base64.encodeToString(androidModel.getBytes(StandardCharsets.UTF_8), Base64.NO_WRAP))
+                .addHeader("authorization", "Bearer " + authCode)
+                .addHeader("client-authorization", "Basic " + Base64.encodeToString((clientId + ":" + clientSecret).getBytes(StandardCharsets.UTF_8), Base64.NO_WRAP))
+                .addHeader("cert-format", "pem")
+                .addHeader("create-session", "true")
+                .addHeader("code-verifier", codeVerifier)
+                .addHeader("redirect-uri", carepartnerAppConfig.getOAuthRedirectUri());
+
+        return this.callSsoApi(requestBuilder, carepartnerAppConfig.getMagDeviceRegisterEndpoint(), null);
+
+    }
+
+    private String createTrimmedCsr(KeyPair keypair, String signAlgo, String cn, String ou, String dc, String o) throws IOException, OperatorCreationException {
+
+        PKCS10CertificationRequestBuilder p10Builder = new JcaPKCS10CertificationRequestBuilder(
+                new X500Principal(
+                        "CN=" + cn +
+                                ", OU=" + ou +
+                                ", DC=" + dc +
+                                ", O=" + o), keypair.getPublic());
+        JcaContentSignerBuilder csBuilder = new JcaContentSignerBuilder(signAlgo);
+        ContentSigner signer = csBuilder.build(keypair.getPrivate());
+        PKCS10CertificationRequest csr = p10Builder.build(signer);
+        StringWriter writer = new StringWriter();
+        JcaPEMWriter jcaPEMWriter = new JcaPEMWriter(writer);
+        jcaPEMWriter.writeObject(csr);
+        jcaPEMWriter.close();
+
+        return writer.toString().replaceAll("-----.*-----", "").replaceAll("\\r", "").replaceAll("\\n", "");
+
+    }
+
+    private String prepareAuth(String clientId, String codeVerifier) throws IOException {
+
+        Request.Builder requestBuilder;
+        Map<String, String> queryParams;
+        String codeChallenge = null;
+        JsonObject providers;
+
+        //Generate SHA-256 code challenge
+        try {
+            codeChallenge = Base64.encodeToString(
+                    MessageDigest.getInstance("SHA-256").digest(codeVerifier.getBytes("ISO_8859_1")),
+                    PKCE_BASE64_ENCODE_SETTINGS);
+        } catch (Exception ex) {
+        }
+
+        //Set params
+        queryParams = new HashMap<String, String>();
+        queryParams.put("client_id", clientId);
+        queryParams.put("response_type", "code");
+        queryParams.put("display", "social_login");
+        queryParams.put("scope", this.carepartnerAppConfig.getOAuthScope());
+        queryParams.put("code_challenge", codeChallenge);
+        queryParams.put("code_challenge_method", "S256");
+        queryParams.put("redirect_uri", this.carepartnerAppConfig.getOAuthRedirectUri());
+        queryParams.put("state", generateRandomDataBase64url(32));
+
+        requestBuilder = new Request.Builder()
+                .get();
+
+        providers = this.callSsoRestApi(requestBuilder, carepartnerAppConfig.getOAuthAuthEndpoint(), queryParams);
+
+        //Get auth url of enterprise login provider
+        for (JsonElement provider : providers.get("providers").getAsJsonArray()) {
+            if (provider.getAsJsonObject().get("provider").getAsJsonObject().get("id").getAsString().contentEquals("enterprise"))
+                return (provider.getAsJsonObject().get("provider").getAsJsonObject().get("auth_url").getAsString());
+        }
+
+        return null;
+
+    }
+
+    private JsonObject createClientCredential(String deviceId) throws IOException {
+
+        RequestBody form;
+        Request.Builder requestBuilder;
+
+        form = new FormBody.Builder()
+                .add("client_id", carepartnerAppConfig.getClientId())
+                .add("nonce", UUID.randomUUID().toString())
+                .build();
+
+        requestBuilder = new Request.Builder()
+                .post(form)
+                .addHeader("device-id", Base64.encodeToString(deviceId.getBytes(StandardCharsets.UTF_8), Base64.NO_WRAP | Base64.URL_SAFE));
+
+        return this.callSsoRestApi(requestBuilder, carepartnerAppConfig.getMagCredentialInitEndpoint(), null);
+
+    }
+
+    private String generateDeviceId() {
+
+        try {
+            byte[] bytes = MessageDigest.getInstance("SHA-256").digest(UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8));
+            StringBuilder stringBuilder = new StringBuilder(bytes.length);
+            for (byte byteChar : bytes)
+                stringBuilder.append(String.format("%02x", byteChar));
+            return stringBuilder.toString();
+        } catch (NoSuchAlgorithmException e) {
+            UserError.Log.e(TAG, "Error generating deviceId! Details: \r\n" + e.getMessage());
+        }
+
+        return null;
+
+    }
+
+    private String generateAndroidModel() {
+        return ANDROID_MODELS[new Random().nextInt(ANDROID_MODELS.length)];
+    }
+
+    private String generateRandomDataBase64url(int length) {
+        SecureRandom secureRandom = new SecureRandom();
+        byte[] codeVerifier = new byte[length];
+        secureRandom.nextBytes(codeVerifier);
+        return Base64.encodeToString(codeVerifier, PKCE_BASE64_ENCODE_SETTINGS);
+    }
+
+    private JsonObject callSsoRestApi(Request.Builder requestBuilder, String endpoint, Map<String, String> queryParams) throws IOException {
+
+        Response response = this.callSsoApi(requestBuilder, endpoint, queryParams);
+        if (response.isSuccessful()) {
+            return JsonParser.parseString(response.body().string()).getAsJsonObject();
+        } else {
+            return null;
+        }
+
+    }
+
+    private Response callSsoApi(Request.Builder requestBuilder, String endpoint, Map<String, String> queryParams) throws IOException {
+
+        HttpUrl.Builder url = null;
+
+        //Build URL
+        url = new HttpUrl.Builder()
+                .scheme("https")
+                .host(carepartnerAppConfig.getSSOServerHost())
+                .addPathSegments(carepartnerAppConfig.getSSOServerPrefix())
+                .addPathSegments(endpoint);
+        //Add query params
+        if (queryParams != null) {
+            for (Map.Entry<String, String> param : queryParams.entrySet()) {
+                url.addQueryParameter(param.getKey(), param.getValue());
+            }
+        }
+        requestBuilder.url(url.build());
+        //Send request
+        return this.getHttpClient().newCall(requestBuilder.build()).execute();
+
+    }
+
+    private boolean refreshCpAppToken() {
+        JsonObject tokenRefreshResult;
+
+        try {
+            //Get config
+            this.loadAppConfig();
+            //Refresh token
+            tokenRefreshResult = this.refreshToken(
+                    credentialStore.getCredential().clientId, credentialStore.getCredential().clientSecret,
+                    credentialStore.getCredential().magIdentifier, credentialStore.getCredential().refreshToken);
+            //Save token
+            credentialStore.updateMobileAppCredential(
+                    tokenRefreshResult.get("access_token").getAsString(),
+                    //new Date(Calendar.getInstance().getTime().getTime() + 15 * 60000),
+                    //new Date(Calendar.getInstance().getTime().getTime() + 30 * 60000),
+                    new Date(Calendar.getInstance().getTime().getTime() + (tokenRefreshResult.get("expires_in").getAsInt() * 1000)),
+                    new Date(Calendar.getInstance().getTime().getTime() + (this.carepartnerAppConfig.getRefreshLifetimeSec() * 1000)),
+                    tokenRefreshResult.get("refresh_token").getAsString());
+            //Completed successfully
+            return true;
+        } catch (Exception ex) {
+            UserError.Log.e(TAG, "Error refreshing CpApp token! Details: \r\n" + ex.getMessage());
+            return false;
+        }
+    }
+
+    private boolean refreshBrowserToken() {
+
         //If not authenticated => unable to refresh
         if (credentialStore.getAuthStatus() == CareLinkCredentialStore.NOT_AUTHENTICATED)
             return false;
 
-        HttpUrl url = null;
-        OkHttpClient httpClient = null;
-        Request.Builder requestBuilder = null;
-        Response response = null;
-        EditableCookieJar cookieJar = null;
+        HttpUrl url;
+        OkHttpClient httpClient;
+        Request.Builder requestBuilder;
+        Response response;
+        EditableCookieJar cookieJar;
 
 
         //Build client with cookies from CredentialStore
@@ -143,15 +575,14 @@ public class CareLinkAuthenticator {
                 //New authentication cookies found
                 if (cookieJar.contains(CARELINK_AUTH_TOKEN_COOKIE_NAME) && cookieJar.contains(CARELINK_TOKEN_VALIDTO_COOKIE_NAME)) {
                     //Update credentials
-                    this.credentialStore.setCredential(
-                            this.carelinkCountry,
+                    this.credentialStore.updateBrowserCredential(
                             cookieJar.getCookies(CARELINK_AUTH_TOKEN_COOKIE_NAME).get(0).value(),
+                            this.parseValidTo(cookieJar.getCookies(CARELINK_TOKEN_VALIDTO_COOKIE_NAME).get(0).value()),
                             this.parseValidTo(cookieJar.getCookies(CARELINK_TOKEN_VALIDTO_COOKIE_NAME).get(0).value()),
                             cookieJar.getAllCookies().toArray(new Cookie[0]));
                 } else {
                     return false;
                 }
-
             }
             //error in response
             else {
@@ -165,13 +596,81 @@ public class CareLinkAuthenticator {
         }
 
         return (credentialStore.getAuthStatus() == CareLinkCredentialStore.AUTHENTICATED);
-
     }
 
-    private void showDialog(Activity context) {
+    private void showProgressDialog(Activity context) {
+        new Handler(Looper.getMainLooper()).post(new Runnable() {
+            @Override
+            public void run() {
+                CareLinkAuthenticator.this.getProgressDialog(context).show();
+            }
+        });
+    }
 
-        //Create dialog
+    private void hideProgressDialog() {
+        if (this.progressDialog != null && this.progressDialog.isShowing()) {
+            this.progressDialog.dismiss();
+        }
+    }
+
+    private AlertDialog getProgressDialog(Activity context) {
+        if (this.progressDialog == null) {
+            AlertDialog.Builder builder;
+            builder = new AlertDialog.Builder(context);
+            builder.setTitle(xdrip.gs(R.string.carelink_auth_login_in_progress));
+            final ProgressBar progressBar = new ProgressBar(context);
+            LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.WRAP_CONTENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT);
+            progressBar.setLayoutParams(lp);
+            builder.setView(progressBar);
+            this.progressDialog = builder.create();
+        }
+        //return builder;
+        return this.progressDialog;
+    }
+
+    private void showBrowserAuthPage(Activity context, String url) {
         final Dialog authDialog = new Dialog(context);
+        this.showAuthWebView(authDialog, url, new WebViewClient() {
+            @Override
+            public void onPageStarted(WebView view, String url, Bitmap favicon) {
+                if (CareLinkAuthenticator.this.extractBrowserLoginCookies(url))
+                    authDialog.dismiss();
+            }
+        });
+    }
+
+    private void showCpAppAuthPage(Activity context, String url) {
+
+        //CustomTabsIntent customTabsIntent = new CustomTabsIntent.Builder().build();
+        //customTabsIntent.launchUrl(
+        //        context, Uri.parse(url));
+
+        final Dialog authDialog = new Dialog(context);
+        this.showAuthWebView(authDialog, url, new WebViewClient() {
+            @Override
+            public void onPageStarted(WebView view, String url, Bitmap favicon) {
+                if (CareLinkAuthenticator.this.extractCpAppAuthCode(url))
+                    //close browser dialog
+                    authDialog.dismiss();
+            }
+
+            @Override
+            public void onReceivedError(WebView view, WebResourceRequest request, WebResourceError error) {
+                //Connection error
+                if (error.getErrorCode() == WebViewClient.ERROR_CONNECT) {
+                    carelinkCommunicationError = true;
+                    authDialog.dismiss();
+                }
+            }
+        });
+    }
+
+    private void showAuthWebView(Dialog authDialog, String url, WebViewClient webViewClient) {
+
+        this.authWebViewCancelled = false;
+
         LinearLayoutCompat layout = new LinearLayoutCompat(authDialog.getContext());
         WebView webView = new WebView(authDialog.getContext());
         webView.setLayoutParams(new LinearLayoutCompat.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
@@ -184,42 +683,86 @@ public class CareLinkAuthenticator {
                 unlock();
             }
         });
+        authDialog.setOnCancelListener(new DialogInterface.OnCancelListener() {
+            @Override
+            public void onCancel(DialogInterface dialogInterface) {
+                authWebViewCancelled = true;
+            }
+        });
 
         //Configure Webview
         webView.getSettings().setJavaScriptEnabled(true);
         webView.getSettings().setUserAgentString("Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Mobile Safari/537.36");
-        HashMap<String, String> headers = new HashMap<>();
-        headers.put("Accept-Language", "en;q=0.9, *;q=0.8");
-        headers.put("Sec-Ch-Ua", "\"Google Chrome\";v=\"117\", \"Not;A=Brand\";v=\"8\", \"Chromium\";v=\"117\"");
-        webView.loadUrl(this.getLoginUrl(), headers);
-        webView.setWebViewClient(new WebViewClient() {
+        webView.loadUrl(url);
+        webView.setWebViewClient(webViewClient);
 
-            @Override
-            public void onPageStarted(WebView view, String url, Bitmap favicon) {
-                if (CareLinkAuthenticator.this.extractCookies(url))
-                    authDialog.dismiss();
-            }
-
-            @Override
-            public void onPageFinished(WebView view, String url) {
-                if (CareLinkAuthenticator.this.extractCookies(url))
-                    authDialog.dismiss();
-            }
-        });
-
-
-        //Set dialog display infos and show it
+        //Set dialog display params and show it
         authDialog.setCancelable(true);
-        /*
-        authDialog.getWindow().setLayout(
-                (int) (context.getResources().getDisplayMetrics().widthPixels),
-                (int) (context.getResources().getDisplayMetrics().heightPixels));
-         */
         authDialog.getWindow().setLayout(LinearLayoutCompat.LayoutParams.MATCH_PARENT, LinearLayoutCompat.LayoutParams.MATCH_PARENT);
         authDialog.show();
+
     }
 
-    protected String getLoginUrl() {
+    private boolean extractCpAppAuthCode(String url) {
+
+        //Redirect url => extract code, completed
+        if (url.contains(this.carepartnerAppConfig.getOAuthRedirectUri())) {
+            try {
+                UrlQuerySanitizer sanitizer = new UrlQuerySanitizer();
+                sanitizer.setAllowUnregisteredParamaters(true);
+                sanitizer.parseUrl(url);
+                authCode = sanitizer.getValue("code");
+            } catch (Exception ex) {
+                UserError.Log.e(TAG, "Error extracting authCode! Details: \r\n" + ex.getMessage());
+            }
+            return true;
+            //Other url => authentication not completed yet
+        } else
+            return false;
+
+    }
+
+    private JsonObject getCpAppRegionConfig() throws IOException {
+
+
+        //Get CarePartner app discover
+        JsonObject endpointConfig = this.getConfigJson(CAREPARTNER_APP_DISCO_URL);
+        //Extract region config of selected country
+        JsonArray countries = endpointConfig.getAsJsonArray("supportedCountries");
+        JsonArray regions = endpointConfig.getAsJsonArray("CP");
+        for (JsonElement country : countries) {
+            if (country.getAsJsonObject().has(this.carelinkCountry.toUpperCase(Locale.ROOT))) {
+                String regionCode = country.getAsJsonObject().get(this.carelinkCountry.toUpperCase(Locale.ROOT)).getAsJsonObject().get("region").getAsString();
+                for (JsonElement region : regions) {
+                    if (region.getAsJsonObject().get("region").getAsString().contentEquals(regionCode)) {
+                        return region.getAsJsonObject();
+                    }
+                }
+            }
+        }
+
+        return null;
+
+    }
+
+    private JsonObject getCpAppSSOConfig(String url) throws IOException {
+        return this.getConfigJson(url);
+    }
+
+    private JsonObject getConfigJson(String url) throws IOException {
+
+        Request request;
+
+        request = new Request.Builder()
+                .url(url)
+                .get()
+                .build();
+        Response response = this.getHttpClient().newCall(request).execute();
+        return JsonParser.parseString(response.body().string()).getAsJsonObject();
+
+    }
+
+    private String getWebAppLoginUrl() {
 
         HttpUrl url = null;
 
@@ -235,14 +778,15 @@ public class CareLinkAuthenticator {
 
     }
 
-    protected String careLinkServer() {
+    private String careLinkServer() {
         if (this.carelinkCountry.equals("us"))
             return CARELINK_CONNECT_SERVER_US;
         else
             return CARELINK_CONNECT_SERVER_EU;
     }
 
-    protected Boolean extractCookies(String url) {
+    private Boolean extractBrowserLoginCookies(String url) {
+
         String cookies = null;
         String authToken = null;
         String host = null;
@@ -288,20 +832,22 @@ public class CareLinkAuthenticator {
                 return false;
 
             //Update credentials
-            this.credentialStore.setCredential(this.carelinkCountry, authToken, validToDate, cookieList.toArray(new Cookie[0]));
+            this.credentialStore.setBrowserCredential(this.carelinkCountry, authToken, validToDate, validToDate, cookieList.toArray(new Cookie[0]));
+            //success
             return true;
         } else
             //error
             return false;
     }
 
-    protected void unlock() {
+    private void unlock() {
         if (available.availablePermits() <= 0)
             available.release();
     }
 
-    protected Date parseValidTo(String validToDateString) {
+    private Date parseValidTo(String validToDateString) {
         for (SimpleDateFormat zonedFormat : VALIDTO_DATE_FORMATS) {
+            //try until translate is successful
             try {
                 return zonedFormat.parse(validToDateString);
             } catch (Exception ex) {
@@ -309,6 +855,5 @@ public class CareLinkAuthenticator {
         }
         return null;
     }
-
 
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/auth/CareLinkCredential.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/auth/CareLinkCredential.java
@@ -4,13 +4,39 @@ import java.util.Calendar;
 import java.util.Date;
 
 import okhttp3.Cookie;
+import okhttp3.Headers;
 
 public class CareLinkCredential {
+
 
     public String country = null;
     public String accessToken = null;
     public Cookie[] cookies = null;
-    public Date tokenValidTo = null;
+    public Date accessValidTo = null;
+    public Date refreshValidTo = null;
+    public CareLinkAuthType authType = null;
+    public String androidModel = null;
+    public String deviceId = null;
+    public String clientId = null;
+    public String clientSecret = null;
+    public String magIdentifier = null;
+    public String refreshToken = null;
+
+
+    public CareLinkAuthentication getAuthentication() {
+
+        //Not authenticated
+        if (this.authType == null || this.getAuthorizationFieldValue() == null)
+            return null;
+
+        //Build authentication
+        Headers.Builder headers = new Headers.Builder();
+        headers.add("Authorization", this.getAuthorizationFieldValue());
+        if (this.authType == CareLinkAuthType.MobileApp)
+            headers.add("mag-identifier", this.magIdentifier);
+        return new CareLinkAuthentication(headers.build(), this.authType);
+
+    }
 
     public String getToken() {
         return accessToken;
@@ -23,12 +49,11 @@ public class CareLinkCredential {
             return "Bearer " + this.getToken();
     }
 
-    public long getExpiresIn() {
-        if (this.tokenValidTo == null)
+    public long getAccessExpiresIn() {
+        if (this.accessValidTo == null)
             return -1;
         else
-            return this.tokenValidTo.getTime() - Calendar.getInstance().getTime().getTime();
+            return this.accessValidTo.getTime() - Calendar.getInstance().getTime().getTime();
     }
 
 }
-

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/auth/CareLinkCredentialStore.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/auth/CareLinkCredentialStore.java
@@ -15,8 +15,9 @@ public class CareLinkCredentialStore {
     private static final String TAG = "CareLinkCredentialStore";
 
     public final static int NOT_AUTHENTICATED = 0;
-    public final static int TOKEN_EXPIRED = 1;
+    public final static int ACCESS_EXPIRED = 1;
     public final static int AUTHENTICATED = 2;
+    public final static int REFRESH_EXPIRED = 3;
 
     private CareLinkCredential credential = null;
     private static CareLinkCredentialStore instance = null;
@@ -37,7 +38,8 @@ public class CareLinkCredentialStore {
             if (!credJson.equals("")) {
                 try {
                     CareLinkCredential savedCred = new GsonBuilder().create().fromJson(credJson, CareLinkCredential.class);
-                    instance.setCredential(savedCred.country, savedCred.accessToken, savedCred.tokenValidTo, savedCred.cookies, false);
+                    instance.setCredential(savedCred.country, savedCred.authType, savedCred.accessToken, savedCred.accessValidTo, savedCred.refreshValidTo, savedCred.cookies,
+                            savedCred.androidModel, savedCred.deviceId, savedCred.clientId, savedCred.clientSecret, savedCred.magIdentifier, savedCred.refreshToken, false);
                 } catch (Exception e) {
                     UserError.Log.d(TAG, "Error when restoring saved Credential: " + e.getMessage());
                 }
@@ -49,17 +51,38 @@ public class CareLinkCredentialStore {
         return instance;
     }
 
-    synchronized void setCredential(String country, String accessToken, Date tokenValidTo, Cookie[] cookies) {
-        this.setCredential(country, accessToken, tokenValidTo, cookies, true);
+    synchronized void setMobileAppCredential(String country, String deviceId, String androidModel, String clientId, String clientSecret, String magIdentifier, String accessToken, String refreshToken, Date accessValidTo, Date refreshValidTo) {
+        this.setCredential(country, CareLinkAuthType.MobileApp, accessToken, accessValidTo, refreshValidTo, null, androidModel, deviceId, clientId, clientSecret, magIdentifier, refreshToken, true);
     }
 
-    protected synchronized void setCredential(String country, String accessToken, Date tokenValidTo, Cookie[] cookies, boolean save) {
+    synchronized void updateMobileAppCredential(String accessToken, Date accessValidTo, Date refreshValidTo, String refreshToken) {
+        this.setCredential(credential.country, CareLinkAuthType.MobileApp, accessToken, accessValidTo, refreshValidTo, null, credential.androidModel, credential.deviceId, credential.clientId, credential.clientSecret, credential.magIdentifier, refreshToken, true);
+    }
+
+    synchronized void updateBrowserCredential(String accessToken, Date accessValidTo, Date refreshValidTo, Cookie[] cookies) {
+        this.setCredential(credential.country, CareLinkAuthType.Browser, accessToken, accessValidTo, refreshValidTo, cookies, null, null, null, null, null, null, true);
+    }
+
+    synchronized void setBrowserCredential(String country, String accessToken, Date accessValidTo, Date refreshValidTo, Cookie[] cookies) {
+        this.setCredential(country, CareLinkAuthType.Browser, accessToken, accessValidTo, refreshValidTo, cookies, null, null, null, null, null, null, true);
+    }
+
+    protected synchronized void setCredential(String country, CareLinkAuthType authType, String accessToken, Date accessValidTo, Date refreshValidTo, Cookie[] cookies, String androidModel, String deviceId, String clientId, String clientSecret, String magIdentifier, String refreshToken, boolean save) {
+
         credential = new CareLinkCredential();
+        credential.authType = authType;
         credential.country = country;
         credential.accessToken = accessToken;
+        credential.accessValidTo = accessValidTo;
         credential.cookies = cookies;
-        credential.tokenValidTo = tokenValidTo;
-        if (credential.accessToken == null || credential.tokenValidTo == null)
+        credential.androidModel = androidModel;
+        credential.deviceId = deviceId;
+        credential.clientId = clientId;
+        credential.clientSecret = clientSecret;
+        credential.magIdentifier = magIdentifier;
+        credential.refreshToken = refreshToken;
+        credential.refreshValidTo = refreshValidTo;
+        if (credential.accessToken == null || credential.accessValidTo == null)
             authStatus = NOT_AUTHENTICATED;
         else
             evaluateExpiration();
@@ -82,18 +105,32 @@ public class CareLinkCredentialStore {
         return authStatus;
     }
 
-    public long getExpiresIn() {
-        if (credential == null || credential.tokenValidTo == null)
+    public long getAccessExpiresIn() {
+        if (credential == null || credential.accessValidTo == null)
             return -1;
         else
-            return credential.tokenValidTo.getTime() - Calendar.getInstance().getTime().getTime();
+            return credential.accessValidTo.getTime() - Calendar.getInstance().getTime().getTime();
     }
 
-    public long getExpiresOn() {
-        if (credential == null || credential.tokenValidTo == null)
+    public long getAccessExpiresOn() {
+        if (credential == null || credential.accessValidTo == null)
             return -1;
         else
-            return credential.tokenValidTo.getTime();
+            return credential.accessValidTo.getTime();
+    }
+
+    public long getRefreshExpiresIn() {
+        if (credential == null || credential.refreshValidTo == null)
+            return -1;
+        else
+            return credential.refreshValidTo.getTime() - Calendar.getInstance().getTime().getTime();
+    }
+
+    public long getRefreshExpiresOn() {
+        if (credential == null || credential.refreshValidTo == null)
+            return -1;
+        else
+            return credential.refreshValidTo.getTime();
     }
 
     synchronized void clear() {
@@ -104,11 +141,12 @@ public class CareLinkCredentialStore {
     }
 
     protected void evaluateExpiration() {
-        if (this.getExpiresIn() < 0)
-            authStatus = TOKEN_EXPIRED;
+        if (this.getRefreshExpiresIn() < 0)
+            authStatus = REFRESH_EXPIRED;
+        else if (this.getAccessExpiresIn() < 0)
+            authStatus = ACCESS_EXPIRED;
         else
             authStatus = AUTHENTICATED;
     }
-
 
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/auth/CarePartnerAppConfig.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/cgm/carelinkfollow/auth/CarePartnerAppConfig.java
@@ -1,0 +1,92 @@
+package com.eveningoutpost.dexdrip.cgm.carelinkfollow.auth;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+public class CarePartnerAppConfig {
+
+    public JsonObject regionConfig = null;
+    public JsonObject ssoConfig = null;
+
+    public String getRegion() {
+        return regionConfig.get("region").getAsString();
+    }
+
+    public String getSSOConfigUrl() {
+        return regionConfig.get("SSOConfiguration").getAsString();
+    }
+
+    public String getCloudBaseUrl() {
+        return regionConfig.get("baseUrlCumulus").getAsString();
+    }
+
+    public String getCareLinkBaseUrl() {
+        return regionConfig.get("baseUrlCareLink").getAsString();
+    }
+
+    public String getSSOServerHost() {
+        return this.getChildJsonString(ssoConfig, "server.hostname");
+    }
+
+    public String getSSOServerPrefix() {
+        return this.getChildJsonString(ssoConfig, "server.prefix");
+    }
+
+    public int getSSOServerPort() {
+        return this.getChildJsonElement(ssoConfig, "server.port").getAsInt();
+    }
+
+    public String getOAuthAuthEndpoint() {
+        return this.getChildJsonString(ssoConfig, "oauth.system_endpoints.authorization_endpoint_path").substring(1);
+    }
+
+    public String getOAuthTokenEndpoint() {
+        return this.getChildJsonString(ssoConfig, "oauth.system_endpoints.token_endpoint_path").substring(1);
+    }
+
+    public String getMagCredentialInitEndpoint() {
+        return this.getChildJsonString(ssoConfig, "mag.system_endpoints.client_credential_init_endpoint_path").substring(1);
+    }
+
+    public String getMagDeviceRegisterEndpoint() {
+        return this.getChildJsonString(ssoConfig, "mag.system_endpoints.device_register_endpoint_path").substring(1);
+    }
+
+    public String getClientId() {
+        return getClientMemberString("client_id");
+    }
+
+    public String getOAuthScope() {
+        return getClientMemberString("scope");
+    }
+
+    public String getOAuthRedirectUri() {
+        return getClientMemberString("redirect_uri");
+    }
+
+    public int getRefreshLifetimeSec() {
+        return Integer.parseInt(getClientMemberString("client_key_custom.lifetimes.oauth2_refresh_token_lifetime_sec"));
+    }
+
+    private String getClientMemberString(String clientMember) {
+        return this.getChildJsonString(this.getChildJsonElement(ssoConfig, "oauth.client.client_ids").getAsJsonArray().get(0)
+                .getAsJsonObject(), clientMember);
+    }
+
+    private String getChildJsonString(JsonObject parent, String path) {
+        return getChildJsonElement(parent, path).getAsString();
+    }
+
+    private JsonElement getChildJsonElement(JsonObject parent, String path) {
+
+        JsonElement obj = parent;
+
+        for (String member : path.split("\\.")) {
+            obj = obj.getAsJsonObject().get(member);
+        }
+
+        return obj;
+
+    }
+
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -87,6 +87,7 @@ import com.eveningoutpost.dexdrip.UtilityModels.pebble.watchface.InstallPebbleWa
 import com.eveningoutpost.dexdrip.WidgetUpdateService;
 import com.eveningoutpost.dexdrip.calibrations.PluggableCalibration;
 import com.eveningoutpost.dexdrip.cgm.carelinkfollow.CareLinkFollowService;
+import com.eveningoutpost.dexdrip.cgm.carelinkfollow.auth.CareLinkAuthType;
 import com.eveningoutpost.dexdrip.cgm.carelinkfollow.auth.CareLinkAuthenticator;
 import com.eveningoutpost.dexdrip.cgm.carelinkfollow.auth.CareLinkCredentialStore;
 import com.eveningoutpost.dexdrip.cgm.nsfollow.NightscoutFollow;
@@ -1196,6 +1197,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
             final Preference carelinkFollowDownloadBoluses = findPreference("clfollow_download_boluses");
             final Preference carelinkFollowDownloadMeals = findPreference("clfollow_download_meals");
             final Preference carelinkFollowDownloadNotifications = findPreference("clfollow_download_notifications");
+            //final Preference carelinkFollowDownloadBasals = findPreference("clfollow_download_basals");
             if (collectionType == DexCollectionType.CLFollow) {
                 //Add CL prefs
                 //collectionCategory.addPreference(carelinkFollowUser);
@@ -1209,6 +1211,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                 collectionCategory.addPreference(carelinkFollowDownloadBoluses);
                 collectionCategory.addPreference(carelinkFollowDownloadMeals);
                 collectionCategory.addPreference(carelinkFollowDownloadNotifications);
+                //collectionCategory.addPreference(carelinkFollowDownloadBasals);
                 //Create prefChange handler
                 final Preference.OnPreferenceChangeListener carelinkFollowListener = new Preference.OnPreferenceChangeListener() {
                     @Override
@@ -1218,6 +1221,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                         return true;
                     }
                 };
+                //Pref click handler for Login
                 final Preference.OnPreferenceClickListener carelinkLoginListener = new Preference.OnPreferenceClickListener() {
                     @Override
                     public boolean onPreferenceClick(Preference preference) {
@@ -1225,17 +1229,18 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                             public void run() {
                                 try {
                                     String country = Pref.getString("clfollow_country", "").toLowerCase();
-                                    if (country.equals(""))
-                                        JoH.static_toast(preference.getContext(), "Country is required!", Toast.LENGTH_LONG);
-                                    else {
+                                    if (country.equals("")) {
+                                        JoH.static_toast(preference.getContext(), xdrip.gs(R.string.carelink_auth_country_required), Toast.LENGTH_LONG);
+                                    } else {
                                         CareLinkAuthenticator authenticator = new CareLinkAuthenticator(country, CareLinkCredentialStore.getInstance());
-                                        if (authenticator.authenticate(getActivity())) {
-                                            JoH.static_toast(preference.getContext(), "Authenticated!", Toast.LENGTH_LONG);
+                                        if (authenticator.authenticate(getActivity(), CareLinkAuthType.MobileApp)) {
+                                            JoH.static_toast(preference.getContext(), xdrip.gs(R.string.carelink_auth_status_authenticated), Toast.LENGTH_LONG);
                                             CareLinkFollowService.resetInstanceAndInvalidateSession();
                                             CollectionServiceStarter.restartCollectionServiceBackground();
                                         }
-                                        else
-                                            JoH.static_toast(preference.getContext(), "Not authenticated!", Toast.LENGTH_LONG);
+                                        else {
+                                            JoH.static_toast(preference.getContext(), xdrip.gs(R.string.carelink_auth_status_not_authenticated), Toast.LENGTH_LONG);
+                                        }
                                     }
                                 } catch (InterruptedException e) {
 
@@ -1276,6 +1281,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                     collectionCategory.removePreference(carelinkFollowDownloadBoluses);
                     collectionCategory.removePreference(carelinkFollowDownloadMeals);
                     collectionCategory.removePreference(carelinkFollowDownloadNotifications);
+                    //collectionCategory.removePreference(carelinkFollowDownloadBasals);
                 } catch (Exception e) {
                     //
                 }
@@ -1615,6 +1621,7 @@ public class Preferences extends BasePreferenceActivity implements SearchPrefere
                     collectionCategory.removePreference(carelinkFollowDownloadBoluses);
                     collectionCategory.removePreference(carelinkFollowDownloadMeals);
                     collectionCategory.removePreference(carelinkFollowDownloadNotifications);
+                    //collectionCategory.removePreference(carelinkFollowDownloadBasals);
                 } catch (Exception e) {
                     //
                 }

--- a/app/src/main/res/values-hu/strings-hu.xml
+++ b/app/src/main/res/values-hu/strings-hu.xml
@@ -1269,6 +1269,34 @@
     <string name="title_nsfollow_url">Nightscout követő URL</string>
     <string name="summary_nsfollow_download_treatments">A kezeléseket is töltse le Nightscout követőként</string>
     <string name="title_nsfollow_download_treatments">Kezelések letöltése</string>
+    <!-- Maybe we can use them later?
+    <string name="title_clfollow_user">CareLink Username</string>
+    <string name="summary_clfollow_user">CareLink login username</string>
+    <string name="title_clfollow_pass">CareLink Password</string>
+    <string name="summary_clfollow_pass">CareLink login password</string>
+    !-->
+    <string name="title_clfollow_country">CareLink ország</string>
+    <string name="summary_clfollow_country">Válassza ki az országát</string>
+    <string name="title_clfollow_patient">Követett beteg felhasználóneve</string>
+    <string name="summary_clfollow_patient">Követett betegfiók felhasználóneve (opcionális)</string>
+    <!-- Maybe we can use them later?
+    <string name="title_clfollow_lang">CareLink Language</string>
+    <string name="summary_clfollow_lang">CareLink language code</string>
+    -->
+    <string name="title_clfollow_login">Bejelentkezés</string>
+    <string name="summary_clfollow_login">Bejelentkezés böngészőben</string>
+    <string name="title_clfollow_grace_period">Türelmi idő</string>
+    <string name="summary_clfollow_grace_period">Várakozási idő adatfeltöltésre (s)</string>
+    <string name="title_clfollow_missed_poll_interval">Várakozási idő adatkimaradnásnál</string>
+    <string name="summary_clfollow_missed_poll_interval">Adatlekérdezés-ismétlések közötti várakozási idő adatkimaradásnál</string>
+    <string name="title_clfollow_download_finger_bgs">VC mérés vérből</string>
+    <string name="summary_clfollow_download_finger_bgs">Ujjbegy VC értékek letöltése CareLink-ből</string>
+    <string name="title_clfollow_download_boluses">Bólusok</string>
+    <string name="summary_clfollow_download_boluses">Bólus adatok letöltése CareLink-ből</string>
+    <string name="title_clfollow_download_meals">Étkezések</string>
+    <string name="summary_clfollow_download_meals">Étkezés adatok letöltése CareLink-ből</string>
+    <string name="title_clfollow_download_notifications">Értesítések</string>
+    <string name="summary_clfollow_download_notifications">Értesítések letöltése CareLink-ből</string>
     <string name="title_ob1_options">OB1 G5/G6 kollektor beállítások</string>
     <string name="summary_use_ob1_g5_collector_service">Teljesen újraír kód. Működnie kell a 4.4 - 9-es Android verziókon. Támogatja a natív módot és még sok mást is</string>
     <string name="title_use_ob1_g5_collector_service">OB1 kollektor használata</string>
@@ -1631,4 +1659,15 @@
     <string name="backing_up">Biztonsági mentés</string>
     <string name="did_backup_ok">Biztonsági mentés kész</string>
     <string name="backup_failed">Biztonsági mentés meghiúsult</string>
+    <string name="carelink_auth_country_required">Ország kötelező!</string>
+    <string name="carelink_auth_status_authenticated">Azonosított állapot!</string>
+    <string name="carelink_auth_status_not_authenticated">Nincs azonosítva!</string>
+    <string name="carelink_auth_login_in_progress">Belépés folyamatban...</string>
+    <string name="carelink_refresh_token_start">Hozzáférés megújítása</string>
+    <string name="carelink_refresh_token_failed">Hozzáférés megújítása sikertelen! Majd újrapróbálja!</string>
+    <string name="carelink_download_start">Adatletöltés indítása</string>
+    <string name="carelink_download_failed">Adatletöltés sikertelen!</string>
+    <string name="carelink_credential_status_not_authenticated">Nincs belépve! Jelentkezzen be!</string>
+    <string name="carelink_credential_status_access_expired">Hozzáférés lejárt! Meg fogja újítani!</string>
+    <string name="carelink_credential_status_refresh_expired">Belépés lejárt! Jelentkezzen be!</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1634,4 +1634,15 @@
     <string name="enable_streaming_dialog_dont_ask_again">Don\'t ask me that again</string>
     <string name="enable_streaming_dialog_title">Connecting libre sensor to bluetooth</string>
     <string name="enable_streaming_dialog_text">Do you want to connect xDrip with this sensor? This will stop libre reader and libre link from receiving alerts. Press yes and scan again to connect (choose don\'t connect if you want to run xDrip with the patched app)</string>
+    <string name="carelink_auth_country_required">Country is required!</string>
+    <string name="carelink_auth_status_authenticated">Authenticated status!</string>
+    <string name="carelink_auth_status_not_authenticated">Not authenticated status!</string>
+    <string name="carelink_auth_login_in_progress">Login in progress...</string>
+    <string name="carelink_refresh_token_start">Start access renewal</string>
+    <string name="carelink_refresh_token_failed">Access renewal failed! Will try again!</string>
+    <string name="carelink_download_start">Start download</string>
+    <string name="carelink_download_failed">Download data failed!</string>
+    <string name="carelink_credential_status_not_authenticated">Not logged in! Please log in!</string>
+    <string name="carelink_credential_status_access_expired">Access expired! Will refresh!</string>
+    <string name="carelink_credential_status_refresh_expired">Login expired! Please log in!</string>
 </resources>

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -9,7 +9,7 @@ android {
 //        abortOnError false
     }
     defaultConfig {
-        applicationId "com.eveningoutpost.dexdripva4"
+        applicationId "com.eveningoutpost.dexdrip"
         minSdkVersion 21
         //noinspection ExpiredTargetSdkVersion
         targetSdkVersion 23


### PR DESCRIPTION
CarePartner app authentication is valid for 1 week, thus even if xdrip is unable to connect to CareLink for a few days (for example due to the lack of internet connection), it will be able to renew the login (refresh the token) automatically in the background after it can connect to CareLink again without needing to login again manually using the browser. The user account restriction applies to this authentication process as well: **a different dedicated follower account must be used in every app, otherwise the previous auth token will be revoked**.

Credits
CarePartner app authentication process is based on the impressive work of **@palmarci** in extracting the entire authentication process of the mobile app.

Limitations
When the same account is logged in from another xdrip or official mobile application the previous login will be closed (authetication token is revoked). **A different dedicated follower account must be used in every official and xdrip app, otherwise the previous auth token will be revoked.**